### PR TITLE
Add DOCKER_RUN_ARGS to the docker run commands in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -277,7 +277,7 @@ if [[ "${BUILD_IMAGES}" == "true" ]]; then
 
     # Build the core image
     run "(10/11) Building builder-core" \
-        "docker run -t --rm --privileged -v $(pwd):/work alpine sh -c 'apk update && apk add --no-cache rsync && \
+        "docker run -t --rm ${DOCKER_RUN_ARGS} --privileged -v $(pwd):/work alpine sh -c 'apk update && apk add --no-cache rsync && \
         cd /work && \
         mkdir -p dockerfiles/core/files/conf/ && \
         if [ ! -f dockerfiles/core/files/conf/config.yml ]; then rsync -rtc --exclude=.build.lock ./conf ./dockerfiles/core/files/; fi && \
@@ -293,7 +293,7 @@ if [[ "${BUILD_IMAGES}" == "true" ]]; then
 
     # Build the certbot image
     run "(11/11) Building builder-certbot" \
-        "docker run -t --rm --privileged -v $(pwd):/work alpine sh -c 'apk update && apk add --no-cache rsync && \
+        "docker run -t --rm ${DOCKER_RUN_ARGS} --privileged -v $(pwd):/work alpine sh -c 'apk update && apk add --no-cache rsync && \
         cd /work && \
         rsync -rtc ./scripts ./dockerfiles/certbot/'; \
         docker build --rm ${DOCKER_BUILD_ARGS} -t builder-certbot dockerfiles/certbot" \


### PR DESCRIPTION
Added DOCKER_RUN_ARGS to the docker run commands in build.sh
While executing build.sh inside a docker container:
apk update inside alpine container fails since proxy parameters are not
passed to the alpine container
hence http://dl-cdn.alpinelinux.org/alpine/v3.2/main/x86_64/APKINDEX.tar.gz
is not accessible

Adding DOCKER_RUN_ARGS