### PR TITLE
Update flashusb.sh

### DIFF
--- a/flashusb.sh
+++ b/flashusb.sh
@@ -115,7 +115,7 @@ if [ -n "${DEV}" ]; then
         _usb=$(echo ${_drive} | awk -F'-' '{print $3}')
         _hex=$(echo ${_usb} | awk -F'_' '{print $NF}')
         _usbpath=${_dev/..\/..\//\/dev/}
-        USB_DRIVE="${_usb/_${_hex}/}-($_usbpath)"
+        USB_DRIVE="${_usb/_${_hex}/}-(${_usbpath})"
     elif ( lsblk -p -S -o NAME,TRAN | grep usb | grep ${DEV} > /dev/null 2>&1 ); then
         USB_DRIVE="NO_USB_NAME-(${DEV})"
     else

--- a/flashusb.sh
+++ b/flashusb.sh
@@ -135,7 +135,7 @@ if [ ! -n "${DEV}" ]; then
             _usb=$(echo ${_drive} | awk -F'-' '{print $3}')
             _hex=$(echo ${_usb} | awk -F'_' '{print $NF}')
             _usbpath=${_dev/..\/..\//\/dev/}
-            USB_NAMES="${USB_NAMES} ${_usb/_${_hex}/}-($_usbpath)"
+            USB_NAMES="${USB_NAMES} ${_usb/_${_hex}/}-(${_usbpath})"
         done
         for _drive in $(lsblk -p -S -o NAME,TRAN | grep usb | awk '{print $1}'); do
             if [[ "${USB_NAMES}" != *"${_drive}"* ]]; then

--- a/flashusb.sh
+++ b/flashusb.sh
@@ -114,7 +114,8 @@ if [ -n "${DEV}" ]; then
         _dev=$(ls -l ${_drive} | awk '{print $NF}')
         _usb=$(echo ${_drive} | awk -F'-' '{print $3}')
         _hex=$(echo ${_usb} | awk -F'_' '{print $NF}')
-        USB_DRIVE="${_usb/_${_hex}/}-(${_dev/..\/..\//\/dev/})"
+        _usbpath=${_dev/..\/..\//\/dev/}
+        USB_DRIVE="${_usb/_${_hex}/}-($_usbpath)"
     elif ( lsblk -p -S -o NAME,TRAN | grep usb | grep ${DEV} > /dev/null 2>&1 ); then
         USB_DRIVE="NO_USB_NAME-(${DEV})"
     else
@@ -133,7 +134,8 @@ if [ ! -n "${DEV}" ]; then
             _dev=$(ls -l ${_drive} | awk '{print $NF}')
             _usb=$(echo ${_drive} | awk -F'-' '{print $3}')
             _hex=$(echo ${_usb} | awk -F'_' '{print $NF}')
-            USB_NAMES="${USB_NAMES} ${_usb/_${_hex}/}-(${_dev/..\/..\//\/dev/})"
+            _usbpath=${_dev/..\/..\//\/dev/}
+            USB_NAMES="${USB_NAMES} ${_usb/_${_hex}/}-($_usbpath)"
         done
         for _drive in $(lsblk -p -S -o NAME,TRAN | grep usb | awk '{print $1}'); do
             if [[ "${USB_NAMES}" != *"${_drive}"* ]]; then


### PR DESCRIPTION
Ubuntu 18.04 and latest versions are using bash 4.4.20.
Ubuntu parse usb path is /dev/sda
centos7.9 is using bash 4.2.46(2).
centos parse usb path is \\/dev/sda and is invalid.
This issue only happend on centos7.9 and is related with bash version.
In order to compatible both Centos and Ubuntu, we change bash codes for both OS.

This patch is verified on Ubuntu18.04 and centos7.9, both are ok.