### PR TITLE
Update Dockerfile.intel

### DIFF
--- a/dockerfiles/uos/Dockerfile.intel
+++ b/dockerfiles/uos/Dockerfile.intel
@@ -38,8 +38,7 @@ RUN ar x linux-image-unsigned-${UBUNTU_RELEASE}_${KERNEL_VERSION}.deb && \
         ./lib/modules/${UBUNTU_RELEASE}/kernel/drivers/net/ethernet/ \
         ./lib/modules/${UBUNTU_RELEASE}/kernel/drivers/gpu/ \
         ./lib/modules/${UBUNTU_RELEASE}/kernel/drivers/video/ \
-        ./lib/modules/${UBUNTU_RELEASE}/kernel/drivers/net/phy/ \
-        ./lib/modules/${UBUNTU_RELEASE}/kernel/drivers/net/wireless/ \
+        ./lib/modules/${UBUNTU_RELEASE}/kernel/drivers/net/ \
         ./lib/modules/${UBUNTU_RELEASE}/kernel/drivers/misc/mei/ \
         ./lib/modules/${UBUNTU_RELEASE}/kernel/drivers/mmc/ \
         ./lib/modules/${UBUNTU_RELEASE}/kernel/drivers/media/mmc/ \


### PR DESCRIPTION
Change the kernel module directory to /net to include global kernel module symboles such as ieee80211_hdr_lan provided by the mac80211 module.