### PR TITLE
Update Dockerfile.intel

### DIFF
--- a/dockerfiles/uos/Dockerfile.intel
+++ b/dockerfiles/uos/Dockerfile.intel
@@ -35,6 +35,7 @@ RUN ar x linux-image-unsigned-${UBUNTU_RELEASE}_${KERNEL_VERSION}.deb && \
     tar -xf data.tar.xz && \
     ar x linux-modules-extra-${UBUNTU_RELEASE}_${KERNEL_VERSION}.deb && \
     tar -xf data.tar.xz \ 
+        ./lib/modules/${UBUNTU_RELEASE}/kernel/net/ \
         ./lib/modules/${UBUNTU_RELEASE}/kernel/drivers/net/ethernet/ \
         ./lib/modules/${UBUNTU_RELEASE}/kernel/drivers/gpu/ \
         ./lib/modules/${UBUNTU_RELEASE}/kernel/drivers/video/ \


### PR DESCRIPTION
Add the kernel /net module directory to include global kernel module symbols such as ieee80211_hdr_lan provided by the mac80211 module. Those symbols are needed by wireless drivers such as iwlwifi.